### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/area44/renovate-config/security/code-scanning/1](https://github.com/area44/renovate-config/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define permissions at the workflow root (applies to all jobs) with `contents: read`, which is sufficient for checkout and test execution in this file.

Change needed:
- File: `.github/workflows/validate.yml`
- Insert after the `on:` trigger section (before `jobs:`):
  - `permissions:`
  - `contents: read`

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
